### PR TITLE
bugfix with RELATAION_HAS_ONE relation

### DIFF
--- a/src/Document/RelationManager.php
+++ b/src/Document/RelationManager.php
@@ -76,8 +76,9 @@ class RelationManager
                     ->find()
                     ->where($externalField, $this->document->get($internalField))
                     ->findOne();
-
-                $this->resolvedRelationIds[$relationName] = (string) $document->getId();
+                if ($document) {
+                    $this->resolvedRelationIds[$relationName] = (string) $document->getId();
+                }
 
                 return $document;
 


### PR DESCRIPTION
If i am trying to get document through RELATION_HAS_ONE i get fatal error if there is no related document in db.